### PR TITLE
Enable startup/shutdown timeout override

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.github.michaelruocco:embedded-mysql-plugin:2.1.6'
+        classpath 'com.github.michaelruocco:embedded-mysql-plugin:2.1.7'
     }
 }
 
@@ -40,7 +40,7 @@ or alternatively:
 
 ```
 plugins {
-    id 'com.github.michaelruocco.embedded-mysql-plugin' version '2.1.6'
+    id 'com.github.michaelruocco.embedded-mysql-plugin' version '2.1.7'
 }
 ```
 
@@ -138,6 +138,7 @@ The default values for each of the underlying properties are:
 * version = 'v5_7_latest'
 * cacheDirectoryPath = <users home directory>/.embedmysql
 * baseDownloadUrl = 'https://dev.mysql.com/get/Downloads/'
+* timeoutSeconds = 30 (default start/stop timeout)
 
 This means the example configuration above could also be expressed as shown below.
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'jacoco'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '2.1.6'
+version = '2.1.7'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtension.groovy
+++ b/src/main/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtension.groovy
@@ -6,6 +6,8 @@ import com.wix.mysql.config.DownloadConfig
 import com.wix.mysql.config.MysqldConfig
 import com.wix.mysql.distribution.Version
 
+import java.util.concurrent.TimeUnit
+
 import static com.wix.mysql.EmbeddedMysql.anEmbeddedMysql
 import static com.wix.mysql.config.DownloadConfig.aDownloadConfig
 import static com.wix.mysql.config.MysqldConfig.aMysqldConfig
@@ -18,6 +20,7 @@ class EmbeddedMysqlExtension {
     private static final String DEFAULT_USERNAME = "user"
     private static final Version DEFAULT_VERSION = v5_7_latest
     private static final Charset DEFAULT_CHARSET = Charset.defaults()
+    private static final int DEFAULT_TIMEOUT_SECONDS = 30
 
     private final ServerVariableValidator serverVariableValidator = new ServerVariableValidator()
     private final CharsetValidator charsetValidator = new CharsetValidator()
@@ -31,6 +34,7 @@ class EmbeddedMysqlExtension {
     private String password = EMPTY_STRING
     private Version version = DEFAULT_VERSION
     private Charset charset = DEFAULT_CHARSET
+    private int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS
     private Map<String, Object> serverVars = new HashMap<String, Object>()
     private String cacheDirectoryPath
     private String baseDownloadUrl
@@ -72,6 +76,14 @@ class EmbeddedMysqlExtension {
 
     Version getVersion() {
         return version
+    }
+
+    void setTimeoutSeconds(int timeoutSeconds) {
+        this.timeoutSeconds = timeoutSeconds
+    }
+
+    int getTimeoutSeconds() {
+        return timeoutSeconds
     }
 
     void setServerCharset(String charset) {
@@ -136,6 +148,7 @@ class EmbeddedMysqlExtension {
                 .withPort(port)
                 .withUser(username, password)
                 .withCharset(charset)
+                .withTimeout(timeoutSeconds, TimeUnit.SECONDS)
 
         if (serverVars)
             serverVars.each { k, v -> builder.withServerVariable(k, v) }

--- a/src/test/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtensionTest.groovy
+++ b/src/test/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtensionTest.groovy
@@ -18,9 +18,11 @@ class EmbeddedMysqlExtensionTest {
     private static final def DEFAULT_USERNAME = "user"
     private static final def DEFAULT_VERSION = v5_7_latest
     private static final def DEFAULT_PORT = 3306
+    private static final def DEFAULT_TIMEOUT_SECONDS = 30
 
     private static final def OVERRIDE_USERNAME = "anotherUser"
     private static final def OVERRIDE_VERSION = v5_6_latest
+    private static final def OVERRIDE_TIMEOUT_SECONDS = 60
 
     private static final def PASSWORD = "password"
 
@@ -49,6 +51,11 @@ class EmbeddedMysqlExtensionTest {
     @Test
     void versionShouldDefaultToDefaultVersion() {
         assertThat(extension.version).isEqualTo(DEFAULT_VERSION)
+    }
+
+    @Test
+    void timeoutShouldDefaultToDefaultTimeout() {
+        assertThat(extension.timeoutSeconds).isEqualTo(DEFAULT_TIMEOUT_SECONDS)
     }
 
     @Test
@@ -86,6 +93,12 @@ class EmbeddedMysqlExtensionTest {
     void shouldSetVersion() {
         extension.version = OVERRIDE_VERSION.name()
         assertThat(extension.version).isEqualTo(OVERRIDE_VERSION)
+    }
+
+    @Test
+    void shouldSetTimeoutSeconds() {
+        extension.timeoutSeconds = OVERRIDE_TIMEOUT_SECONDS
+        assertThat(extension.timeoutSeconds).isEqualTo(OVERRIDE_TIMEOUT_SECONDS)
     }
 
     @Test

--- a/src/test/groovy/uk/co/mruoc/mysql/StartStopEmbeddedMysqlTaskTest.groovy
+++ b/src/test/groovy/uk/co/mruoc/mysql/StartStopEmbeddedMysqlTaskTest.groovy
@@ -22,6 +22,7 @@ class StartStopEmbeddedMysqlTaskTest {
     private static final def VERSION = v5_6_23.name()
     private static final def CHARSET = Charset.LATIN1
     private static final def SERVER_VARS = ["explicit_defaults_for_timestamp": true]
+    private static final def TIMEOUT_SECONDS = 45
 
     private def project = ProjectBuilder.builder().build()
 
@@ -74,6 +75,7 @@ class StartStopEmbeddedMysqlTaskTest {
         extension.serverCharset = CHARSET.charset
         extension.serverCollate = CHARSET.collate
         extension.serverVars = SERVER_VARS
+        extension.timeoutSeconds = TIMEOUT_SECONDS
         extension
     }
 


### PR DESCRIPTION
Allows the default startup/shutdown timeout for the underlying wix-embedded-mysql library to be overridden from a default of 30 seconds (per https://github.com/wix/wix-embedded-mysql/blob/master/wix-embedded-mysql/src/main/java/com/wix/mysql/config/MysqldConfig.java#L109)