### PR TITLE
make temp directory configurable / default to a location under build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.github.michaelruocco:embedded-mysql-plugin:2.1.8'
+        classpath 'com.github.michaelruocco:embedded-mysql-plugin:2.1.9'
     }
 }
 
@@ -40,7 +40,7 @@ or alternatively:
 
 ```
 plugins {
-    id 'com.github.michaelruocco.embedded-mysql-plugin' version '2.1.8'
+    id 'com.github.michaelruocco.embedded-mysql-plugin' version '2.1.9'
 }
 ```
 
@@ -176,6 +176,7 @@ The default values for each of the underlying properties are:
 * baseDownloadUrl = 'https://dev.mysql.com/get/Downloads/'
 * timeoutSeconds = 30 (default start/stop timeout)
 * schema = '' (empty set, process will not create additional schemas and will use 'databaseName')
+* tempDir = 'build/mysql-temp/' (default temporary directory)
 
 This means the example configuration above could also be expressed as shown below.
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'jacoco'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
-version = '2.1.8'
+version = '2.1.9'
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtension.groovy
+++ b/src/main/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtension.groovy
@@ -21,6 +21,7 @@ class EmbeddedMysqlExtension {
     private static final Version DEFAULT_VERSION = v5_7_latest
     private static final Charset DEFAULT_CHARSET = Charset.defaults()
     private static final int DEFAULT_TIMEOUT_SECONDS = 30
+    private static final String DEFAULT_TEMP_DIR = "build/mysql-temp/"
 
     private final ServerVariableValidator serverVariableValidator = new ServerVariableValidator()
     private final CharsetValidator charsetValidator = new CharsetValidator()
@@ -36,6 +37,7 @@ class EmbeddedMysqlExtension {
     private Version version = DEFAULT_VERSION
     private Charset charset = DEFAULT_CHARSET
     private int timeoutSeconds = DEFAULT_TIMEOUT_SECONDS
+    private String tempDir = DEFAULT_TEMP_DIR
     private Map<String, Object> serverVars = new HashMap<String, Object>()
     private String cacheDirectoryPath
     private String baseDownloadUrl
@@ -93,6 +95,14 @@ class EmbeddedMysqlExtension {
 
     int getTimeoutSeconds() {
         return timeoutSeconds
+    }
+
+    void setTempDir(String tempDir) {
+        this.tempDir = tempDir
+    }
+
+    String getTempDir() {
+        return tempDir
     }
 
     void setServerCharset(String charset) {
@@ -164,6 +174,7 @@ class EmbeddedMysqlExtension {
                 .withUser(username, password)
                 .withCharset(charset)
                 .withTimeout(timeoutSeconds, TimeUnit.SECONDS)
+                .withTempDir(tempDir)
 
         if (serverVars)
             serverVars.each { k, v -> builder.withServerVariable(k, v) }

--- a/src/test/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtensionTest.groovy
+++ b/src/test/groovy/uk/co/mruoc/mysql/EmbeddedMysqlExtensionTest.groovy
@@ -17,10 +17,12 @@ class EmbeddedMysqlExtensionTest {
     private static final def DEFAULT_VERSION = v5_7_latest
     private static final def DEFAULT_PORT = 3306
     private static final def DEFAULT_TIMEOUT_SECONDS = 30
+    private static final def DEFAULT_TEMP_DIR = 'build/mysql-temp/'
 
     private static final def OVERRIDE_USERNAME = "anotherUser"
     private static final def OVERRIDE_VERSION = v5_6_latest
     private static final def OVERRIDE_TIMEOUT_SECONDS = 60
+    private static final def OVERRIDE_TEMP_DIR = 'build/mysql-custom-temp'
 
     private static final def PASSWORD = "password"
 
@@ -54,6 +56,11 @@ class EmbeddedMysqlExtensionTest {
     @Test
     void timeoutShouldDefaultToDefaultTimeout() {
         assertThat(extension.timeoutSeconds).isEqualTo(DEFAULT_TIMEOUT_SECONDS)
+    }
+
+    @Test
+    void tempDirShouldDefaultToTarget() {
+        assertThat(extension.tempDir).isEqualTo(DEFAULT_TEMP_DIR)
     }
 
     @Test
@@ -97,6 +104,12 @@ class EmbeddedMysqlExtensionTest {
     void shouldSetTimeoutSeconds() {
         extension.timeoutSeconds = OVERRIDE_TIMEOUT_SECONDS
         assertThat(extension.timeoutSeconds).isEqualTo(OVERRIDE_TIMEOUT_SECONDS)
+    }
+
+    @Test
+    void shouldSetTempDir() {
+        extension.tempDir = OVERRIDE_TEMP_DIR
+        assertThat(extension.tempDir).isEqualTo(OVERRIDE_TEMP_DIR)
     }
 
     @Test

--- a/src/test/groovy/uk/co/mruoc/mysql/StartStopEmbeddedMysqlTaskTest.groovy
+++ b/src/test/groovy/uk/co/mruoc/mysql/StartStopEmbeddedMysqlTaskTest.groovy
@@ -26,6 +26,7 @@ class StartStopEmbeddedMysqlTaskTest {
     private static final def CHARSET = Charset.LATIN1
     private static final def SERVER_VARS = ["explicit_defaults_for_timestamp": true]
     private static final def TIMEOUT_SECONDS = 45
+    private static final def TEMP_DIR = 'build/mysql-target/'
 
     private def project = ProjectBuilder.builder().build()
 
@@ -95,6 +96,7 @@ class StartStopEmbeddedMysqlTaskTest {
         extension.serverCollate = CHARSET.collate
         extension.serverVars = SERVER_VARS
         extension.timeoutSeconds = TIMEOUT_SECONDS
+        extension.tempDir = TEMP_DIR
         extension
     }
 


### PR DESCRIPTION
make temp directory configurable and use a more gradle-friendly default (wix-embedded-mysql defaults this to `target/`, which survives a gradle clean)